### PR TITLE
[fix] USE文を修正、文字コードを設定

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -8,3 +8,5 @@ ENV MYSQL_PASSWORD=password
 VOLUME /var/lib/mysql
 # init.sqlをコンテナの/docker-entrypoint-init.db.dと共有することで初期化の時に実行される
 COPY init.sql /docker-entrypoint-initdb.d
+# MySQLの設定ファイルを共有
+COPY my.cnf /etc/mysql/conf.d

--- a/mysql/init.sql
+++ b/mysql/init.sql
@@ -1,4 +1,4 @@
-USE MYSQL_DATABASE;
+USE mydatabase;
 
 CREATE TABLE users (
     user_id SERIAL PRIMARY KEY,

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,8 @@
+[mysqld]
+character-set-server = utf8mb4
+
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4


### PR DESCRIPTION
①テスト時にinit.sqlが動いていないことに気づけていなかった
環境変数を読み込めていない事に対する変更
環境変数を直接読み込むことはできないようなのでシンプルに書き込みました
②文字化け
文字コードが一部utf8になっていなかったので反映
デフォルトがutf8になっているはずだという記事を見るも、今回なぜ別のものになっているのかは不明なので指定しました

③今回のテスト用に作った関数(routes.py)

```

import models
from database import DatabaseHandler

def database_check(table_name):
    if table_name == "users":
        query = "SELECT * FROM users"
    if table_name == "schedules":
        query = "SELECT * FROM schedules"
    with DatabaseHandler() as db:
        return db.get_data(query = query, params = None)

@router.get("/test")
def test():
    print(f"usersテーブルの最初の状態: {database_check('users')}")
    print(f"schedulesテーブルの最初の状態: {database_check('schedules')}")
    models.create_user("new_user", "new_email", "new_password", "new_address")
    print(f"create_user()の実行後: {database_check('users')}")
    models.update_user(3, "田中太郎", "tarou@gmail.com", "taro\'s password", "太郎のおうち")
    print(f"update_user()の実行後: {database_check('users')}")
    models.create_schedule(1, "2030-06-09", "名古屋遺跡", "愛知県名古屋市1-55")
    print(f"create_schedule()の実行後: {database_check('schedules')}")
    models.update_schedule(4, "2050-07-14", "博多博物館", "福岡県博多市8-999")
    print(f"update_schedule()の実行後: {database_check('schedules')}")
    models.delete_schedule(4)
    print(f"delete_schedule()の実行後: {database_check('schedules')}")
    print(f"user_idが1のユーザーの住所は: {models.get_user_address(1)}")
    print(f"user_idが1のユーザーのスケジュールは: {models.get_schedules(1)}")
    print(f"user_idが2のユーザーの住所は: {models.get_user_address(2)}")
    print(f"user_idが2のユーザーのスケジュールは: {models.get_schedules(2)}")
```