### PR TITLE
エラーページとエラーキャッチの整備

### DIFF
--- a/apis/main.py
+++ b/apis/main.py
@@ -1,9 +1,14 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, HTTPException, status
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import RedirectResponse
+from fastapi.exceptions import RequestValidationError
+from fastapi.templating import Jinja2Templates
 from routers.routes import router as routes_router
 from routers.views import router as views_router
+from pymysql import MySQLError
 
 app = FastAPI()
+templates = Jinja2Templates(directory="templates")
 
 # ルーターをインクルード
 app.include_router(routes_router)
@@ -12,3 +17,24 @@ app.include_router(views_router)
 # 静的ファイルの設定
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
+
+@app.exception_handler(HTTPException)
+def exception_handler_http(request: Request, exc: HTTPException):
+    if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+        return RedirectResponse(url="/login")
+    body = {"messages": [str(exc)]}
+    return templates.TemplateResponse(name="error.html", request=body)
+
+@app.exception_handler(RequestValidationError)
+def exception_handler_request_valid_error(request: Request, exc: RequestValidationError):
+    body = {"messages": []}
+    for error in exc.errors():
+        loc = error["loc"][1]
+        msg = error["msg"]
+        body["messages"].append(f"{loc} {msg}")
+    return templates.TemplateResponse(name="error.html", request=body)
+
+@app.exception_handler(MySQLError)
+def exception_handler(request: Request, exc: MySQLError):
+    body = {"messages": ["データベース接続エラーです"]}
+    return templates.TemplateResponse(name="error.html", request=body)

--- a/apis/routers/routes.py
+++ b/apis/routers/routes.py
@@ -344,7 +344,7 @@ def route(
 
         return templates.TemplateResponse(name="map.html", request=request)
     except Exception as e:
-        return RedirectResponse(url=f"/error?error={e}", status_code=302)
+        raise HTTPException(status_code=400, detail=str(e))
 
 # リクエストの発行元を確認する
 def verify_origin(request: Request):

--- a/apis/routers/views.py
+++ b/apis/routers/views.py
@@ -82,8 +82,3 @@ async def user_info_edit(request: Request, user=Depends(get_current_user)):
         return templates.TemplateResponse("user_edit.html", {"request": request, "user": user})
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Failed to load user information: {str(e)}")
-    
-# エラー画面への遷移
-@router.get("/error", response_class=HTMLResponse)
-async def error(request: Request, error: str):
-    return templates.TemplateResponse("error.html", {"request": request, "error": error})

--- a/apis/templates/error.html
+++ b/apis/templates/error.html
@@ -1,4 +1,22 @@
 {% extends 'base.html' %}
 {% block contents %}
-<h1>error [{{ error }}]</h1>
+<div style="text-align: center;">
+  <h1 style="margin: 20px 0 30px;">エラーです！</h1>
+  <ul id="error-list"></ul>
+</div>
+
+
+<script>
+  const errorBody = JSON.parse('{{ request|tojson }}');
+  const ul = document.getElementById("error-list");
+  const errorMessages = errorBody["messages"];
+
+  for (let i=0; i<errorMessages.length; i++) {
+    const li = document.createElement("li");
+    const text = errorMessages[i];
+    li.textContent = text;
+    ul.appendChild(li);
+  }
+
+</script>
 {% endblock %}


### PR DESCRIPTION
各所で発生するようになっていたエラーをキャッチする処理を実装
httpexceptionの401認証エラーのみ/loginへリダイレクト、残りはエラーページをそのurlで表示するようになっております
ブラウザバック有効のなのと、データの受け渡しの都合上リダイレクトではなくこちらの方法にしました